### PR TITLE
Fix/Client/T2. Showing Task modal after a user delete the task

### DIFF
--- a/client/app/tasks/components/DeleteTaskModal.tsx
+++ b/client/app/tasks/components/DeleteTaskModal.tsx
@@ -20,7 +20,7 @@ const DeleteTaskModal = ({ isOpen, onClose, taskId }: DeleteTaskModalProps) => {
   const { onDeleteTask, isPending } = useDeleteTask(onClose)
 
   return (
-    <AlertDialog open={isOpen} onOpenChange={() => onClose(true)}>
+    <AlertDialog open={isOpen}>
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>Are you absolutely sure?</AlertDialogTitle>
@@ -30,7 +30,9 @@ const DeleteTaskModal = ({ isOpen, onClose, taskId }: DeleteTaskModalProps) => {
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
-          <AlertDialogCancel disabled={isPending}>Cancel</AlertDialogCancel>
+          <AlertDialogCancel disabled={isPending} onClick={() => onClose(true)}>
+            Cancel
+          </AlertDialogCancel>
           <AlertDialogAction
             isLoading={isPending}
             onClick={() => onDeleteTask(taskId)}


### PR DESCRIPTION
## Describe your changes
* FIx the bug that showing task modal after a user delete the task

## Issue

## URL
http://localhost:3000/tasks

## Screenshot (if you made the UI)

https://github.com/HAK2024/fairy-share/assets/66394413/f7bd5501-b0ac-4e6b-9731-7d510962b0f2


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings and no errors

