### PR TITLE
Fix/client/create-expnese-form

### DIFF
--- a/client/app/expenses/components/CreateExpenseForm.tsx
+++ b/client/app/expenses/components/CreateExpenseForm.tsx
@@ -37,7 +37,7 @@ const CreateExpenseForm = () => {
             name='fee'
             render={({ field }) => (
               <FormItem>
-                <FormLabel isRequired>Expenses&nbsp;($)</FormLabel>
+                <FormLabel isRequired>Expense&nbsp;($)</FormLabel>
                 <FormControl>
                   <Input
                     type='number'

--- a/client/app/expenses/components/CreateExpenseForm.tsx
+++ b/client/app/expenses/components/CreateExpenseForm.tsx
@@ -45,6 +45,7 @@ const CreateExpenseForm = () => {
                     min='0.01'
                     step='0.01'
                     {...field}
+                    value={field.value === 0 ? '' : field.value}
                   />
                 </FormControl>
                 <FormMessage />

--- a/client/app/expenses/components/EditExpenseForm.tsx
+++ b/client/app/expenses/components/EditExpenseForm.tsx
@@ -43,7 +43,7 @@ const EditExpenseForm = ({ defaultData }: { defaultData: ExpenseType }) => {
             name='fee'
             render={({ field }) => (
               <FormItem>
-                <FormLabel isRequired>Expenses&nbsp;($)</FormLabel>
+                <FormLabel isRequired>Expense&nbsp;($)</FormLabel>
                 <FormControl>
                   <Input
                     type='number'
@@ -51,6 +51,7 @@ const EditExpenseForm = ({ defaultData }: { defaultData: ExpenseType }) => {
                     min='0.01'
                     step='0.01'
                     {...field}
+                    value={field.value === 0 ? '' : field.value}
                   />
                 </FormControl>
                 <FormMessage />

--- a/client/app/expenses/hooks/useCreateExpense.ts
+++ b/client/app/expenses/hooks/useCreateExpense.ts
@@ -16,7 +16,6 @@ export const useCreateExpense = () => {
 
   const form = useForm<ExpenseSchema>({
     resolver: expenseResolver,
-    // TODO: Set empty to fee if I figured out a way
     defaultValues: {
       itemName: '',
       fee: 0,


### PR DESCRIPTION
## Describe your changes
* Set default value to empty

No. | Page/API | BE/FE | Error details
-- | -- | -- | --
26 | /expenses/create| FE | Set default expense in create expense form empty.

https://docs.google.com/spreadsheets/d/1Y36fTDY15lipiH9FL24fXAq6_7rQ58T9pMWFne6shvk/edit?pli=1#gid=0




## Issue
none

## URL
http://localhost:3000/

## Screenshot (if you made the UI)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings and no errors
